### PR TITLE
Analyze buffering ratio

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,7 +160,17 @@ def analyze_rate_rebuffering(event_df: pd.DataFrame) -> None:
 
 
 def analyze_buffering_ratio(event_df: pd.DataFrame) -> None:
-    pass
+    """Compute the fraction of time spent in buffering events over the duration of the video session"""
+
+    print("Analyzing buffering ratio ...")
+    df = (
+        event_df[["session", "seq", "rebuffering_seconds", "rebuffering_count"]]
+        .groupby("session")
+        # Filter on session duration >= 6 (one minute)
+        .filter(lambda x: x["seq"].count() >= MIN_SESSION_DURATION)
+        .reset_index(drop=True)
+    )
+    print(df.head(n=200))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Data is in the following format:


```
     session  seq  rebuffering_seconds  rebuffering_count
0          5    1                  0.0                0.0
1          5    2                 10.0                0.0
2          5    3                 10.0                0.0
3          5    4                 10.0                0.0
4          5    5                 16.0                0.0
5          5    6                 19.0                0.0
6          5    7                 14.0                0.0
7          5    8                 13.0                0.0
8          5    9                 13.0                0.0
9          5   10                 19.0                0.0
10         5   11                 19.0                0.0
11         5   12                 16.0                0.0
12         5   13                 19.0                0.0
13         5   14                 19.0                0.0
14         5   15                 10.0                0.0
15         5   16                 19.0                0.0
16         5   17                 11.0                0.0
17         5   18                 15.0                0.0
18         5   19                 20.0                0.0
19         5   20                 13.0                0.0
20         5   21                 10.0                0.0
21         5   22                 19.0                0.0
22         5   23                 19.0                0.0
23         5   24                 19.0                0.0
24         5   25                 10.0                0.0
25         5   26                 16.0                0.0
26         5   27                 17.0                0.0
...
164       48   11                  1.0                2.0
165       48   12                  0.0                0.0
166       52    1                  NaN                1.0
167       52    2                  0.0                1.0
168       52    3                  0.0                NaN
169       52    4                  0.0                1.0
170       52    5                  NaN                NaN
171       52    6                  NaN                NaN
172       52    7                  NaN                NaN
173       52    8                  NaN                NaN
174       52    9                  NaN                NaN
175       52   10                  NaN                NaN
...
```

@NabajeetBarman can you confirm a couple questions:
1. Should we treat `NaN` as `0`? I think it means that the player did not send that information. Should we just drop the entire session instead?
2.  Brightcove defines `rebuffering_seconds` as `The total number of seconds the player was “buffering” in the period between the last two player events`.  Looking at the sample data above, it looks like it's taking into account player buffering events (zero rebuffering_count but positive rebuffering_seconds). Can you confirm how should we calculate buffering ratio in this case?